### PR TITLE
Add support to describe analyzers in reST

### DIFF
--- a/project/lint/analyzers/context_processors.py
+++ b/project/lint/analyzers/context_processors.py
@@ -3,6 +3,12 @@ import ast
 from .base import BaseAnalyzer, ModuleVisitor, Result
 
 
+DESCRIPTION = """
+As of Django 1.4, ``{name}`` function has been deprecated and will be removed
+in Django 1.5. Use ``{propose}`` instead.
+"""
+
+
 class ContextProcessorsVisitor(ast.NodeVisitor):
 
     def __init__(self):
@@ -32,11 +38,7 @@ class ContextProcessorsAnalyzer(BaseAnalyzer):
         for name, node in visitor.found:
             propose = visitor.deprecated_items[name]
             result = Result(
-                description = (
-                    'As of Django 1.4, %r function has beed deprecated and '
-                    'will be removed in Django 1.5. Use %r instead.'
-                    % (name, propose)
-                ),
+                description = DESCRIPTION.format(name=name, propose=propose),
                 path = filepath,
                 line = node.lineno)
             lines = self.get_file_lines(filepath, node.lineno, node.lineno)

--- a/project/lint/analyzers/db_backends.py
+++ b/project/lint/analyzers/db_backends.py
@@ -3,6 +3,12 @@ import ast
 from .base import BaseAnalyzer, Result
 
 
+DESCRIPTION = """
+``{name}`` database backend has been deprecated in Django 1.2 and removed in 1.4.
+Use ``{propose}`` instead.
+"""
+
+
 class DB_BackendsVisitor(ast.NodeVisitor):
 
     def __init__(self):
@@ -29,10 +35,7 @@ class DB_BackendsAnalyzer(BaseAnalyzer):
         for name, node in visitor.found:
             propose = visitor.removed_items[name]
             result = Result(
-                description = (
-                    '%r database backend has beed deprecated in Django 1.2 '
-                    'and removed in 1.4. Use %r instead.' % (name, propose)
-                ),
+                description = DESCRIPTION.format(name=name, propose=propose),
                 path = filepath,
                 line = node.lineno)
             lines = self.get_file_lines(filepath, node.lineno, node.lineno)

--- a/project/lint/analyzers/formtools.py
+++ b/project/lint/analyzers/formtools.py
@@ -3,6 +3,12 @@ import ast
 from .base import BaseAnalyzer, Result, DeprecatedCodeVisitor
 
 
+DESCRIPTION = """
+``{name}`` function has been deprecated in Django 1.3 and will be removed in
+1.5. Use ``django.contrib.formtools.utils.form_mac()`` instead.
+"""
+
+
 class FormToolsVisitor(DeprecatedCodeVisitor):
 
     interesting = {
@@ -20,12 +26,7 @@ class FormToolsAnalyzer(BaseAnalyzer):
         visitor.visit(code)
         for name, node, start, stop in visitor.get_found():
             result = Result(
-                description = (
-                    "%r function has beed deprecated in Django 1.3 and "
-                    "will be removed in 1.5. Use "
-                    "'django.contrib.formtools.utils.form_hmac()' instead."
-                    % name
-                ),
+                description = DESCRIPTION.format(name=name),
                 path = filepath,
                 line = start)
             lines = self.get_file_lines(filepath, start, stop)

--- a/project/lint/analyzers/generic_views.py
+++ b/project/lint/analyzers/generic_views.py
@@ -3,6 +3,12 @@ import ast
 from .base import BaseAnalyzer, Result, DeprecatedCodeVisitor
 
 
+DESCRIPTION = """
+``{name}`` function has been deprecated in Django 1.3 and will be removed in
+1.5.
+"""
+
+
 class GenericViewsVisitor(DeprecatedCodeVisitor):
 
     interesting = {
@@ -42,10 +48,7 @@ class GenericViewsAnalyzer(BaseAnalyzer):
         visitor.visit(code)
         for name, node, start, stop in visitor.get_found():
             result = Result(
-                description = (
-                    '%r function has been deprecated in Django 1.3 and will '
-                    'be removed in 1.5.' % name
-                ),
+                description = DESCRIPTION.format(name=name),
                 path = filepath,
                 line = start)
             lines = self.get_file_lines(filepath, start, stop)

--- a/project/lint/analyzers/syntax_error.py
+++ b/project/lint/analyzers/syntax_error.py
@@ -2,6 +2,9 @@ import os
 from .base import BaseAnalyzer, Result
 
 
+DESCRIPTION = 'Syntax error: {msg}.'
+
+
 class SyntaxErrorAnalyzer(BaseAnalyzer):
     """
     Return notes for all fiels with syntax error.
@@ -10,7 +13,11 @@ class SyntaxErrorAnalyzer(BaseAnalyzer):
     def analyze_file(self, path, code):
         if not isinstance(code, SyntaxError):
             return
-        result = Result(description=code.msg, path=path, line=code.lineno)
+        result = Result(
+            description=DESCRIPTION.format(msg=code.msg),
+            path=path,
+            line=code.lineno,
+        )
         lines = self.get_file_lines(path, code.lineno, code.lineno)
         for i, important, line in lines:
             result.source.add_line(i, line, important)

--- a/project/lint/analyzers/template_loaders.py
+++ b/project/lint/analyzers/template_loaders.py
@@ -3,6 +3,12 @@ import ast
 from .base import BaseAnalyzer, Result
 
 
+DESCRIPTION = """
+``{name}`` function has been deprecated in Django 1.2 and removed in 1.4. Use
+``{propose}`` class instead.
+"""
+
+
 class TemplateLoadersVisitor(ast.NodeVisitor):
 
     def __init__(self):
@@ -32,10 +38,7 @@ class TemplateLoadersAnalyzer(BaseAnalyzer):
         for name, node in visitor.found:
             propose = visitor.removed_items[name]
             result = Result(
-                description = (
-                    '%r function has been deprecated in Django 1.2 and '
-                    'removed in 1.4. Use %r class instead.' % (name, propose)
-                ),
+                description = DESCRIPTION.format(name=name, propose=propose),
                 path = filepath,
                 line = node.lineno)
             lines = self.get_file_lines(filepath, node.lineno, node.lineno)

--- a/project/lint/migrations/0008_add_fix_description_html_field.py
+++ b/project/lint/migrations/0008_add_fix_description_html_field.py
@@ -1,0 +1,45 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'Fix.description_html'
+        db.add_column('lint_fix', 'description_html', self.gf('django.db.models.fields.TextField')(default=''), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'Fix.description_html'
+        db.delete_column('lint_fix', 'description_html')
+
+
+    models = {
+        'lint.fix': {
+            'Meta': {'ordering': "['path', 'line']", 'object_name': 'Fix'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'description_html': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'line': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'report': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fixes'", 'to': "orm['lint.Report']"}),
+            'solution': ('django.db.models.fields.TextField', [], {}),
+            'source': ('django.db.models.fields.TextField', [], {})
+        },
+        'lint.report': {
+            'Meta': {'ordering': "['-created_on']", 'object_name': 'Report'},
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'github_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'hash': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'stage': ('django.db.models.fields.CharField', [], {'default': "'queue'", 'max_length': '10'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['lint']

--- a/project/lint/migrations/0009_fill_fix_description_html_field.py
+++ b/project/lint/migrations/0009_fill_fix_description_html_field.py
@@ -1,0 +1,48 @@
+# encoding: utf-8
+import datetime
+
+from south.db import db
+from south.v2 import DataMigration
+
+from django.db import models
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        from django.utils.encoding import smart_str, force_unicode
+        from docutils.core import publish_parts
+
+        for fix in orm.Fix.objects.all():
+            parts = publish_parts(source=smart_str(fix.description), writer_name='html4css1')
+            fix.description_html = force_unicode(parts['fragment'])
+            fix.save()
+
+    def backwards(self, orm):
+        pass
+
+    models = {
+        'lint.fix': {
+            'Meta': {'ordering': "['path', 'line']", 'object_name': 'Fix'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'description_html': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'line': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'report': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fixes'", 'to': "orm['lint.Report']"}),
+            'solution': ('django.db.models.fields.TextField', [], {}),
+            'source': ('django.db.models.fields.TextField', [], {})
+        },
+        'lint.report': {
+            'Meta': {'ordering': "['-created_on']", 'object_name': 'Report'},
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'github_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'hash': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'stage': ('django.db.models.fields.CharField', [], {'default': "'queue'", 'max_length': '10'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['lint']

--- a/project/lint/migrations/0009_fill_fix_description_html_field.py
+++ b/project/lint/migrations/0009_fill_fix_description_html_field.py
@@ -5,17 +5,14 @@ from south.db import db
 from south.v2 import DataMigration
 
 from django.db import models
+from ..utils import rst2html
 
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        from django.utils.encoding import smart_str, force_unicode
-        from docutils.core import publish_parts
-
         for fix in orm.Fix.objects.all():
-            parts = publish_parts(source=smart_str(fix.description), writer_name='html4css1')
-            fix.description_html = force_unicode(parts['fragment'])
+            fix.description_html = rst2html(fix.description)
             fix.save()
 
     def backwards(self, orm):

--- a/project/lint/models.py
+++ b/project/lint/models.py
@@ -76,6 +76,7 @@ class Fix(models.Model):
 
     report = models.ForeignKey(Report, related_name='fixes')
     description = models.TextField()
+    description_html = models.TextField()
     path = models.CharField(max_length=255)
     line = models.PositiveIntegerField()
     source = models.TextField()
@@ -83,6 +84,10 @@ class Fix(models.Model):
 
     class Meta:
         ordering = ['path', 'line']
+
+    def save(self, *args, **kwargs):
+        self.description_html = rst2html(self.description)
+        super(Fix, self).save(*args, **kwargs)
 
 
 @receiver(models.signals.post_save, sender=Report)

--- a/project/lint/models.py
+++ b/project/lint/models.py
@@ -14,6 +14,7 @@ from django.utils.hashcompat import sha_constructor
 
 from .managers import ReportManager
 from .settings import CONFIG
+from .utils import rst2html
 
 
 STAGES = ('queue', 'cloning', 'parsing', 'analyzing', 'done')

--- a/project/lint/tests/__init__.py
+++ b/project/lint/tests/__init__.py
@@ -1,6 +1,7 @@
 from .test_models import ReportTestCase
 from .test_parsers import ParserTests
 from .test_tasks import TasksTests
+from .test_utils import RST2HTMLTests
 
 from .test_analyzers_result import ResultTests
 from .test_attribute_visitor import AttributeVisitorTests

--- a/project/lint/tests/__init__.py
+++ b/project/lint/tests/__init__.py
@@ -1,4 +1,4 @@
-from .test_models import ReportTestCase
+from .test_models import ReportTestCase, FixTestCase
 from .test_parsers import ParserTests
 from .test_tasks import TasksTests
 from .test_utils import RST2HTMLTests

--- a/project/lint/tests/test_models.py
+++ b/project/lint/tests/test_models.py
@@ -2,8 +2,14 @@ from datetime import datetime, timedelta
 
 from django.test import TestCase
 
-from ..models import Report
+from ..models import Report, Fix
 from ..settings import CONFIG
+
+
+def create_fix(**kwargs):
+    kwargs['line'] = 0
+    kwargs['report'] = Report.objects.create(url='https://github.com/django/django')
+    return Fix.objects.create(**kwargs)
 
 
 class ReportTestCase(TestCase):
@@ -26,3 +32,17 @@ class ReportTestCase(TestCase):
 
         self.assertEqual(qs.count(), 1)
         self.assertEqual(qs[0].pk, 1)
+
+
+class FixTestCase(TestCase):
+
+    def setUp(self):
+        self.fix = create_fix(description='Fix description.')
+
+    def test_caches_description_html(self):
+        self.assertEqual(self.fix.description_html, '<p>Fix description.</p>\n')
+
+    def test_updates_description_html(self):
+        self.fix.description = 'Updated fix description.'
+        self.fix.save()
+        self.assertEqual(self.fix.description_html, '<p>Updated fix description.</p>\n')

--- a/project/lint/tests/test_syntax_error_analyzer.py
+++ b/project/lint/tests/test_syntax_error_analyzer.py
@@ -17,7 +17,7 @@ class SyntaxErrorAnalyzerTests(TestCase):
         results = list(analyzer.analyze())
         self.assertEqual(len(results), 1)
         result = results[0]
-        self.assertEqual(result.description, 'invalid syntax')
+        self.assertEqual(result.description, 'Syntax error: invalid syntax.')
         self.assertEqual(result.path, 'syntax_error.py')
         self.assertEqual(result.line, 2)
         self.assertItemsEqual(result.source, [

--- a/project/lint/tests/test_utils.py
+++ b/project/lint/tests/test_utils.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+from ..utils import rst2html
+
+
+class RST2HTMLTests(TestCase):
+
+    def test_converts_rst_to_html(self):
+        result = rst2html('Fix *description*.')
+        self.assertEqual(result, '<p>Fix <em>description</em>.</p>\n')
+
+    def test_handles_unicode(self):
+        result = rst2html(u'Описание фикса.')
+        self.assertEqual(result, u'<p>Описание фикса.</p>\n')

--- a/project/lint/utils.py
+++ b/project/lint/utils.py
@@ -1,0 +1,7 @@
+from django.utils.encoding import force_unicode, smart_str
+from docutils.core import publish_parts
+
+
+def rst2html(text):
+    parts = publish_parts(source=smart_str(text), writer_name='html4css1')
+    return force_unicode(parts['fragment'])

--- a/project/settings/common.py
+++ b/project/settings/common.py
@@ -125,6 +125,7 @@ TEMPLATE_DIRS = (
 INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.staticfiles',
+    'django.contrib.markup',
     'lint',
     'south',
     'djcelery',

--- a/project/settings/common.py
+++ b/project/settings/common.py
@@ -125,7 +125,6 @@ TEMPLATE_DIRS = (
 INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.staticfiles',
-    'django.contrib.markup',
     'lint',
     'south',
     'djcelery',

--- a/project/templates/lint/tags/results_fix.html
+++ b/project/templates/lint/tags/results_fix.html
@@ -1,5 +1,7 @@
+{% load markup %}
+
 <h3>{{ fix.path }}</h3>
-<p>{{ fix.description }}</p>
+{{ fix.description|restructuredtext }}
 
 {% if source_result %}
 <div class="fix-bg">

--- a/project/templates/lint/tags/results_fix.html
+++ b/project/templates/lint/tags/results_fix.html
@@ -1,7 +1,5 @@
-{% load markup %}
-
 <h3>{{ fix.path }}</h3>
-{{ fix.description|restructuredtext }}
+{{ fix.description_html|safe }}
 
 {% if source_result %}
 <div class="fix-bg">

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,7 @@ celery==2.2.7
 django-celery==2.2.4
 django-picklefield==0.1.9
 django_compressor==0.9.2
+docutils==0.9.1
 kombu==1.2.0
 pyparsing==1.5.6
 python-dateutil==1.5


### PR DESCRIPTION
Added support to describe analyzers using reStructuredText markup language. It enables us:
- to use better text formatting capabilities (at least links and paragraphs);
- to convert analysis results into HTML, PDF, plain text, etc.

While Markdown has more readable syntax, I've chose reST, because reST is much more mature and capable, and it is more common in the Python world.

There is no styles for result HTML, but this is a minor issue, because we will have a new design is the near future.
