### PR TITLE
Move all repository clones handling code into a separate submodule

### DIFF
--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -12,12 +12,12 @@ class CloneError(Exception):
 
 
 @contextmanager
-def clone(url, repo_path):
-    tarball_path = _download_tarball(url, repo_path)
-    _extract_tarball(tarball_path, repo_path)
+def clone(url, path):
+    tarball_path = _download_tarball(url, path)
+    repo_path = _extract_tarball(tarball_path)
     _remove_tarball(tarball_path)
     yield repo_path
-    _remove_clone(repo_path)
+    _remove_clone(path)
 
 
 def _check_language(url):
@@ -54,9 +54,11 @@ def _download_tarball(url, repo_path):
     return tarball_path
 
 
-def _extract_tarball(tarball_path, repo_path):
+def _extract_tarball(tarball_path):
+    repo_path = os.path.join(os.path.dirname(tarball_path))
     if Popen(['tar', 'xf', tarball_path, '-C', repo_path]).wait():
         raise CloneError("Can't extract tarball")
+    return repo_path
 
 
 def _remove_tarball(tarball_path):

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 import requests
+from contextlib import contextmanager
 from subprocess import Popen
 from django.utils import simplejson as json
 from .settings import CONFIG
@@ -9,12 +11,15 @@ class CloneError(Exception):
     pass
 
 
+@contextmanager
 def clone(url, repo_path):
     _check_language(url)
     tarball_url = _get_tarball_url(url)
     tarball_path = _download_tarball(tarball_url, repo_path)
     _extract_tarball(tarball_path, repo_path)
     _remove_tarball(tarball_path)
+    yield repo_path
+    _remove_clone(repo_path)
 
 
 def _check_language(url):
@@ -56,3 +61,10 @@ def _extract_tarball(tarball_path, repo_path):
 
 def _remove_tarball(tarball_path):
     os.unlink(tarball_path)
+
+
+def _remove_clone(repo_path):
+    try:
+        shutil.rmtree(repo_path)
+    except OSError:
+        pass

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -59,8 +59,6 @@ def _get_tarball_url(url):
 def _download_tarball(url, path):
     _check_language(url)
     tarball_url = _get_tarball_url(url)
-    if not os.path.exists(path):
-        os.makedirs(path)
     tarball_path = os.path.join(path, 'archive.tar.gz')
     curl_string = 'curl %s --connect-timeout %d --max-filesize %d -L -s -o %s' % (
         tarball_url, CONFIG['GITHUB_TIMEOUT'], CONFIG['MAX_TARBALL_SIZE'], tarball_path

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import shutil
 import tempfile
@@ -14,6 +15,11 @@ class CloneError(Exception):
 
 @contextmanager
 def tempdir(root=None):
+    try:
+        os.makedirs(root)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
     path = tempfile.mkdtemp(dir=root)
     yield path
     shutil.rmtree(path)

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -15,11 +15,12 @@ class CloneError(Exception):
 
 @contextmanager
 def tempdir(root=None):
-    try:
-        os.makedirs(root)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
+    if root is not None:
+        try:
+            os.makedirs(root)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
     path = tempfile.mkdtemp(dir=root)
     try:
         yield path

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -15,7 +15,6 @@ class CloneError(Exception):
 def clone(url, path):
     tarball_path = _download_tarball(url, path)
     repo_path = _extract_tarball(tarball_path)
-    _remove_tarball(tarball_path)
     yield repo_path
     _remove_clone(path)
 
@@ -60,10 +59,6 @@ def _extract_tarball(tarball_path):
     if Popen(['tar', 'xf', tarball_path, '-C', repo_path]).wait():
         raise CloneError("Can't extract tarball")
     return repo_path
-
-
-def _remove_tarball(tarball_path):
-    os.unlink(tarball_path)
 
 
 def _remove_clone(repo_path):

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -13,9 +13,7 @@ class CloneError(Exception):
 
 @contextmanager
 def clone(url, repo_path):
-    _check_language(url)
-    tarball_url = _get_tarball_url(url)
-    tarball_path = _download_tarball(tarball_url, repo_path)
+    tarball_path = _download_tarball(url, repo_path)
     _extract_tarball(tarball_path, repo_path)
     _remove_tarball(tarball_path)
     yield repo_path
@@ -42,7 +40,9 @@ def _get_tarball_url(url):
     return 'https://github.com/%s/tarball/%s' % (url, branch)
 
 
-def _download_tarball(tarball_url, repo_path):
+def _download_tarball(url, repo_path):
+    _check_language(url)
+    tarball_url = _get_tarball_url(url)
     if not os.path.exists(repo_path):
         os.makedirs(repo_path)
     tarball_path = os.path.join(repo_path, 'archive.tar.gz')

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -21,8 +21,10 @@ def tempdir(root=None):
         if e.errno != errno.EEXIST:
             raise
     path = tempfile.mkdtemp(dir=root)
-    yield path
-    shutil.rmtree(path)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path)
 
 
 @contextmanager

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -1,0 +1,43 @@
+import os
+import requests
+from subprocess import Popen
+from django.utils import simplejson as json
+from .settings import CONFIG
+
+
+class CloneError(Exception):
+    pass
+
+
+def clone(url, repo_path):
+    user, repo = url.split('/')
+    # Get info about repo, we need python containing repos only
+    r = requests.get('https://api.github.com/repos/%s/languages' % url,
+                     timeout=CONFIG['GITHUB_TIMEOUT'])
+    if not r.ok or r.status_code != 200:
+        raise CloneError('Not found')
+    data = json.loads(r.content)
+    if not 'Python' in data.keys():
+        raise CloneError("Repo language hasn't Python code")
+
+    # Get branch to download
+    r = requests.get('https://api.github.com/repos/%s' % url,
+                     timeout=CONFIG['GITHUB_TIMEOUT'])
+    if not r.ok or r.status_code != 200:
+        raise CloneError('Cannot fetch information about repo')
+    data = json.loads(r.content)
+    branch = data['master_branch'] or 'master'
+    tarball = 'https://github.com/%s/tarball/%s' % (url, branch)
+
+    # Donwload tarball with curl
+    if not os.path.exists(repo_path):
+        os.makedirs(repo_path)
+    filepath = os.path.join(repo_path, 'archive.tar.gz')
+    curl_string = 'curl %s --connect-timeout %d --max-filesize %d -L -s -o %s' % (
+        tarball, CONFIG['GITHUB_TIMEOUT'], CONFIG['MAX_TARBALL_SIZE'], filepath
+    )
+    if Popen(curl_string.split()).wait():
+        raise CloneError("Can't download tarball")
+    if Popen(['tar', 'xf', filepath, '-C', repo_path]).wait():
+        raise CloneError("Can't extract tarball")
+    os.unlink(filepath)

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -56,12 +56,12 @@ def _get_tarball_url(url):
     return 'https://github.com/%s/tarball/%s' % (url, branch)
 
 
-def _download_tarball(url, repo_path):
+def _download_tarball(url, path):
     _check_language(url)
     tarball_url = _get_tarball_url(url)
-    if not os.path.exists(repo_path):
-        os.makedirs(repo_path)
-    tarball_path = os.path.join(repo_path, 'archive.tar.gz')
+    if not os.path.exists(path):
+        os.makedirs(path)
+    tarball_path = os.path.join(path, 'archive.tar.gz')
     curl_string = 'curl %s --connect-timeout %d --max-filesize %d -L -s -o %s' % (
         tarball_url, CONFIG['GITHUB_TIMEOUT'], CONFIG['MAX_TARBALL_SIZE'], tarball_path
     )

--- a/project/lint/ghclone.py
+++ b/project/lint/ghclone.py
@@ -55,7 +55,8 @@ def _download_tarball(url, repo_path):
 
 
 def _extract_tarball(tarball_path):
-    repo_path = os.path.join(os.path.dirname(tarball_path))
+    repo_path = os.path.join(os.path.dirname(tarball_path), 'repo')
+    os.makedirs(repo_path)
     if Popen(['tar', 'xf', tarball_path, '-C', repo_path]).wait():
         raise CloneError("Can't extract tarball")
     return repo_path

--- a/project/lint/models.py
+++ b/project/lint/models.py
@@ -89,16 +89,3 @@ class Fix(models.Model):
     def save(self, *args, **kwargs):
         self.description_html = rst2html(self.description)
         super(Fix, self).save(*args, **kwargs)
-
-
-@receiver(models.signals.post_save, sender=Report)
-def delete_unused_repos(sender=Report, **kwargs):
-    if kwargs.get('raw', False):
-        return
-    report = kwargs['instance']
-    if report.stage == 'done' or report.error:
-        path = report.get_repo_path()
-        try:
-            shutil.rmtree(path)
-        except OSError:
-            pass

--- a/project/lint/models.py
+++ b/project/lint/models.py
@@ -63,11 +63,6 @@ class Report(models.Model):
         expiration_date = timedelta(days=EXPIRATION_DAYS) + self.created_on
         return datetime.now() > expiration_date
 
-    def get_repo_path(self):
-        if self.hash:
-            return os.path.normpath(os.path.join(CONFIG['CLONES_ROOT'], self.hash))
-        return None
-
     @models.permalink
     def get_absolute_url(self):
         return ('lint_results', (), {'hash': self.hash})

--- a/project/lint/tasks.py
+++ b/project/lint/tasks.py
@@ -1,53 +1,11 @@
-import os
-import requests
-from subprocess import Popen
-
 from celery.task import task
 from django.conf import settings
 from django.utils import simplejson as json
 
 from .analyzers.loader import get_analyzers
+from .ghclone import clone
 from .models import Fix
 from .parsers import Parser
-from .settings import CONFIG
-
-
-class CloneError(Exception):
-    pass
-
-
-def clone(url, repo_path):
-    user, repo = url.split('/')
-    # Get info about repo, we need python containing repos only
-    r = requests.get('https://api.github.com/repos/%s/languages' % url,
-                     timeout=CONFIG['GITHUB_TIMEOUT'])
-    if not r.ok or r.status_code != 200:
-        raise CloneError('Not found')
-    data = json.loads(r.content)
-    if not 'Python' in data.keys():
-        raise CloneError("Repo language hasn't Python code")
-
-    # Get branch to download
-    r = requests.get('https://api.github.com/repos/%s' % url,
-                     timeout=CONFIG['GITHUB_TIMEOUT'])
-    if not r.ok or r.status_code != 200:
-        raise CloneError('Cannot fetch information about repo')
-    data = json.loads(r.content)
-    branch = data['master_branch'] or 'master'
-    tarball = 'https://github.com/%s/tarball/%s' % (url, branch)
-
-    # Donwload tarball with curl
-    if not os.path.exists(repo_path):
-        os.makedirs(repo_path)
-    filepath = os.path.join(repo_path, 'archive.tar.gz')
-    curl_string = 'curl %s --connect-timeout %d --max-filesize %d -L -s -o %s' % (
-        tarball, CONFIG['GITHUB_TIMEOUT'], CONFIG['MAX_TARBALL_SIZE'], filepath
-    )
-    if Popen(curl_string.split()).wait():
-        raise CloneError("Can't download tarball")
-    if Popen(['tar', 'xf', filepath, '-C', repo_path]).wait():
-        raise CloneError("Can't extract tarball")
-    os.unlink(filepath)
 
 
 def parse(path):

--- a/project/lint/tasks.py
+++ b/project/lint/tasks.py
@@ -38,17 +38,16 @@ def exception_handle(func):
 def process_report(report):
     report.stage = 'cloning'
     report.save()
-    path = report.get_repo_path()
-    clone(report.github_url, path)
 
-    report.stage = 'parsing'
-    report.save()
-    parsed_code = parse(path)
+    with clone(report.github_url, report.get_repo_path()) as path:
+        report.stage = 'parsing'
+        report.save()
+        parsed_code = parse(path)
 
-    report.stage = 'analyzing'
-    report.save()
-    for analyzer in get_analyzers():
-        for result in analyzer(parsed_code, path).analyze():
-            save_result(report, result)
-    report.stage = 'done'
-    report.save()
+        report.stage = 'analyzing'
+        report.save()
+        for analyzer in get_analyzers():
+            for result in analyzer(parsed_code, path).analyze():
+                save_result(report, result)
+        report.stage = 'done'
+        report.save()

--- a/project/lint/tasks.py
+++ b/project/lint/tasks.py
@@ -39,7 +39,7 @@ def process_report(report):
     report.stage = 'cloning'
     report.save()
 
-    with clone(report.github_url, report.get_repo_path()) as path:
+    with clone(report.github_url) as path:
         report.stage = 'parsing'
         report.save()
         parsed_code = parse(path)

--- a/project/lint/tests/__init__.py
+++ b/project/lint/tests/__init__.py
@@ -1,6 +1,6 @@
+from .test_ghclone import CloneTests
 from .test_models import ReportTestCase, FixTestCase
 from .test_parsers import ParserTests
-from .test_tasks import TasksTests
 from .test_utils import RST2HTMLTests
 
 from .test_analyzers_result import ResultTests

--- a/project/lint/tests/__init__.py
+++ b/project/lint/tests/__init__.py
@@ -1,4 +1,4 @@
-from .test_ghclone import CloneTests
+from .test_ghclone import TempDirTests, CloneTests
 from .test_models import ReportTestCase, FixTestCase
 from .test_parsers import ParserTests
 from .test_utils import RST2HTMLTests

--- a/project/lint/tests/test_ghclone.py
+++ b/project/lint/tests/test_ghclone.py
@@ -5,12 +5,12 @@ import shutil
 
 from django.test import TestCase
 
+from ..ghclone import CloneError, clone
 from ..models import Report
 from ..settings import CONFIG
-from ..tasks import CloneError, clone
 
 
-class TasksTests(TestCase):
+class CloneTests(TestCase):
 
     def setUp(self):
         self.report1 = Report.objects.create(url='https://github.com/yumike/djangolint')

--- a/project/lint/tests/test_ghclone.py
+++ b/project/lint/tests/test_ghclone.py
@@ -1,13 +1,77 @@
 from __future__ import with_statement
 
+import errno
 import os
 import shutil
+import mock
 
 from django.test import TestCase
 
-from ..ghclone import CloneError, clone
+from ..ghclone import CloneError, tempdir, clone
 from ..models import Report
 from ..settings import CONFIG
+
+
+class TempDirTests(TestCase):
+
+    def setUp(self):
+        self.makedirs_patcher = mock.patch('os.makedirs')
+        self.mkdtemp_patcher = mock.patch('tempfile.mkdtemp')
+        self.rmtree_patcher = mock.patch('shutil.rmtree')
+
+        self.makedirs = self.makedirs_patcher.start()
+        self.mkdtemp = self.mkdtemp_patcher.start()
+        self.rmtree = self.rmtree_patcher.start()
+
+    def tearDown(self):
+        self.makedirs_patcher.stop()
+        self.mkdtemp_patcher.stop()
+        self.rmtree_patcher.start()
+
+    def test_creates_temp_dir(self):
+        with tempdir(root='root') as path:
+            pass
+        self.mkdtemp.assert_called_once_with(dir='root')
+        self.assertEqual(path, self.mkdtemp.return_value)
+
+    def test_doesnt_require_explicit_root(self):
+        with tempdir() as path:
+            pass
+        self.mkdtemp.assert_called_once_with(dir=None)
+
+    def test_tries_to_create_root_if_passed(self):
+        with tempdir(root='root') as path:
+            pass
+        self.makedirs.assert_called_once_with('root')
+
+    def test_passes_silenty_if_root_already_exists(self):
+        self.makedirs.side_effect = OSError(errno.EEXIST, 'File exists', 'root')
+        with tempdir(root='root') as path:
+            pass
+
+    def test_raises_oserror_if_cannot_create_root(self):
+        self.makedirs.side_effect = OSError(errno.EACCES, 'Permission denied', 'root')
+        with self.assertRaises(OSError):
+            with tempdir(root='root') as path:
+                pass
+
+    def test_doesnt_try_to_create_root_if_isnt_passed(self):
+        with tempdir() as path:
+            pass
+        self.assertFalse(self.makedirs.called)
+
+    def test_removes_dir_on_the_exit(self):
+        with tempdir() as path:
+            self.assertFalse(self.rmtree.called)
+        self.rmtree.assert_called_once_with(path)
+
+    def test_removes_dir_if_exception_is_raised(self):
+        try:
+            with tempdir() as path:
+                raise Exception
+        except Exception:
+            pass
+        self.rmtree.assert_called_once_with(path)
 
 
 class CloneTests(TestCase):

--- a/project/lint/tests/test_ghclone.py
+++ b/project/lint/tests/test_ghclone.py
@@ -2,14 +2,12 @@ from __future__ import with_statement
 
 import errno
 import os
-import shutil
 import mock
 
 from django.test import TestCase
 
 from ..ghclone import CloneError, tempdir, clone
 from ..models import Report
-from ..settings import CONFIG
 
 
 class TempDirTests(TestCase):

--- a/project/lint/tests/test_ghclone.py
+++ b/project/lint/tests/test_ghclone.py
@@ -17,39 +17,12 @@ class CloneTests(TestCase):
         self.report2 = Report.objects.create(url='https://github.com/xobb1t/notexistentrepo')
         self.report3 = Report.objects.create(url='https://github.com/mirrors/linux')
 
-    def tearDown(self):
-        try:
-            shutil.rmtree(self.report1.get_repo_path())
-        except OSError:
-            pass
-        try:
-            shutil.rmtree(self.report2.get_repo_path())
-        except OSError:
-            pass
-        try:
-            shutil.rmtree(self.report3.get_repo_path())
-        except OSError:
-            pass
-
     def test_clone(self):
-        path1 = self.report1.get_repo_path()
-        clone(self.report1.github_url, path1)
-        self.assertTrue(os.path.exists(path1))
+        with clone(self.report1.github_url) as path:
+            self.assertTrue(os.path.exists(path))
         with self.assertRaises(CloneError):
-            clone(self.report2.github_url, self.report2.get_repo_path())
+            with clone(self.report2.github_url):
+                pass
         with self.assertRaises(CloneError):
-            clone(self.report3.github_url, self.report3.get_repo_path())
-
-
-    def test_files_delete(self):
-        path1 = self.report1.get_repo_path()
-        clone(self.report1.github_url, path1)
-        self.report1.stage = 'done'
-        self.report1.save()
-        self.assertFalse(os.path.exists(path1))
-        self.report1.stage = 'whait'
-        self.report1.save()
-        clone(self.report1.github_url, path1)
-        self.report1.error = 'error'
-        self.report1.save()
-        self.assertFalse(os.path.exists(path1))
+            with clone(self.report3.github_url):
+                pass

--- a/project/lint/tests/test_tasks.py
+++ b/project/lint/tests/test_tasks.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 
 from ..models import Report
 from ..settings import CONFIG
-from ..tasks import DownloadError, download
+from ..tasks import CloneError, clone
 
 
 class TasksTests(TestCase):
@@ -31,25 +31,25 @@ class TasksTests(TestCase):
         except OSError:
             pass
 
-    def test_download(self):
+    def test_clone(self):
         path1 = self.report1.get_repo_path()
-        download(self.report1.github_url, path1)
+        clone(self.report1.github_url, path1)
         self.assertTrue(os.path.exists(path1))
-        with self.assertRaises(DownloadError):
-            download(self.report2.github_url, self.report2.get_repo_path())
-        with self.assertRaises(DownloadError):
-            download(self.report3.github_url, self.report3.get_repo_path())
+        with self.assertRaises(CloneError):
+            clone(self.report2.github_url, self.report2.get_repo_path())
+        with self.assertRaises(CloneError):
+            clone(self.report3.github_url, self.report3.get_repo_path())
 
 
     def test_files_delete(self):
         path1 = self.report1.get_repo_path()
-        download(self.report1.github_url, path1)
+        clone(self.report1.github_url, path1)
         self.report1.stage = 'done'
         self.report1.save()
         self.assertFalse(os.path.exists(path1))
         self.report1.stage = 'whait'
         self.report1.save()
-        download(self.report1.github_url, path1)
+        clone(self.report1.github_url, path1)
         self.report1.error = 'error'
         self.report1.save()
         self.assertFalse(os.path.exists(path1))

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,3 +4,4 @@ django-kombu==0.9.2
 Fabric==1.4.3
 pycrypto==2.6
 ssh==1.7.14
+mock==1.0b1


### PR DESCRIPTION
Move all code related to repository clones handling into a separate submodule. The rest of the lint app should know nothing about how repositories are cloned and removed.
